### PR TITLE
Try importing from Pillow before falling back to the original PIL

### DIFF
--- a/amigatottf.py
+++ b/amigatottf.py
@@ -12,7 +12,10 @@
 
 from struct import unpack
 
-import Image
+try:
+	from PIL import Image
+except ImportError:
+	import Image
 
 class AmigaFont(object):
 

--- a/convert.py
+++ b/convert.py
@@ -13,7 +13,10 @@
 # * GNU General Public License for more details.
 
 import tempfile, os, subprocess, shutil, optparse
-import Image, ImageChops, ImageOps
+try:
+    from PIL import Image, ImageChops, ImageOps
+except ImportError:
+    import Image, ImageChops, ImageOps
 from itertools import *
 from math import sqrt, floor, ceil
 

--- a/outliner.py
+++ b/outliner.py
@@ -1,5 +1,7 @@
-import Image
-import ImageOps
+try:
+    from PIL import Image, ImageOps
+except ImportError:
+    import Image, ImageOps
 
 # ccw & intersect from:
 # http://www.bryceboe.com/2006/10/23/line-segment-intersection-algorithm/

--- a/pcftottf.py
+++ b/pcftottf.py
@@ -10,7 +10,10 @@
 # * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # * GNU General Public License for more details.
 
-from PcfFontFile import *
+try:
+    from PIL.PcfFontFile import *
+except ImportError:
+    from PcfFontFile import *
 
 class PcfFontFileUnicode(PcfFontFile):
     def __init__(self, fp):


### PR DESCRIPTION
The [official version of PIL](http://www.pythonware.com/products/pil/) hasn't been updated since 2009, and [Pillow](http://python-imaging.github.io/) is easier to install on modern systems; however, the relevant classes are now in the `PIL` namespace instead of the global namespace. This pull request modifies the code to try importing the imaging classes from the `PIL` namespace; if that fails, the global namespace will be used as a fallback.
